### PR TITLE
Improve $expand performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ A [Postman](https://www.getpostman.com/) Collection with a multitude of demo req
 | Batch Requests                        | A.4       | No          |   0 / ?    |
 | MultiDatastream Extension             | A.5       | No          |   0 / ?    |
 | DataArray Extension                   | A.6       | No          |   0 / ?    |
-| Observation Creation via MQTT         | A.7       | Yes         |   0 / 1    |
-| Receiving Updates via MQTT            | A.8       | Yes         |   0 / 5    |
+| Observation Creation via MQTT         | A.7       | Yes         |   1 / 1    |
+| Receiving Updates via MQTT            | A.8       | Yes         |   5 / 5    |
 
 ## Notes:
 #### MQTT Extension

--- a/app/src/test/java/org/n52/sta/ITRootResponseTest.java
+++ b/app/src/test/java/org/n52/sta/ITRootResponseTest.java
@@ -55,14 +55,15 @@ import java.io.IOException;
  */
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 @Testcontainers
-public class ITRootResponseTest {
+public class ITRootResponseTest extends ConformanceTests {
 
     protected final static String jsonMimeType = "application/json";
 
-    @Value("${server.rootUrl}")
-    private String rootUrl;
-
     private ObjectMapper mapper = new ObjectMapper();
+
+    ITRootResponseTest(@Value("${server.rootUrl}") String rootUrl) {
+        super(rootUrl);
+    }
 
     @Test
     public void rootResponseIsCorrect() throws IOException {

--- a/core/src/main/java/org/n52/sta/data/repositories/EntityGraphRepository.java
+++ b/core/src/main/java/org/n52/sta/data/repositories/EntityGraphRepository.java
@@ -48,6 +48,18 @@ import java.util.Optional;
 @NoRepositoryBean
 public interface EntityGraphRepository<T, I> extends JpaSpecificationExecutor<T>, JpaRepository<T, I> {
 
+
+    /**
+     * Retrieves an entity by its id. Additionally fetches all related entities given by the provided EntityGraph.
+     * All provided Graphs are merged internally.
+     *
+     * @param id must not be {@literal null}.
+     * @param fetchGraphs string representation of EntityGraph.
+     * @return the entity with the given id or {@literal Optional#empty()} if none found.
+     * @throws IllegalArgumentException if {@literal id} is {@literal null}.
+     */
+     Optional<T> findById(Long id, FetchGraph... fetchGraphs);
+
     /**
      * Returns a single entity matching the given {@link Specification} or {@link Optional#empty()} if none found.
      * Additionally fetches all related entities given by the provided EntityGraph. All provided Graphs are merged

--- a/core/src/main/java/org/n52/sta/data/repositories/MessageBusRepository.java
+++ b/core/src/main/java/org/n52/sta/data/repositories/MessageBusRepository.java
@@ -56,6 +56,7 @@ import org.hibernate.graph.GraphParser;
 import org.hibernate.graph.RootGraph;
 import org.n52.series.db.beans.AbstractFeatureEntity;
 import org.n52.series.db.beans.DescribableEntity;
+import org.n52.series.db.beans.IdEntity;
 import org.n52.series.db.beans.PhenomenonEntity;
 import org.n52.series.db.beans.PlatformEntity;
 import org.n52.series.db.beans.ProcedureEntity;
@@ -93,6 +94,7 @@ public class MessageBusRepository<T, I extends Serializable>
     private final String FETCHGRAPH_HINT = "javax.persistence.fetchgraph";
     private final String IDENTIFIER = DescribableEntity.PROPERTY_IDENTIFIER;
     private final String STAIDENTIFIER = DescribableEntity.PROPERTY_STA_IDENTIFIER;
+    private final String ID = IdEntity.PROPERTY_ID;
 
     private final JpaEntityInformation entityInformation;
     private final STAEventHandler mqttHandler;
@@ -199,6 +201,17 @@ public class MessageBusRepository<T, I extends Serializable>
     @Transactional
     public Optional<T> findByIdentifier(String identifier, EntityGraphRepository.FetchGraph... entityGraphs) {
         return findByQuery(createIdentifierQuery(identifier, IDENTIFIER), entityGraphs);
+    }
+
+    @Transactional
+    public Optional<T> findById(Long id, EntityGraphRepository.FetchGraph... entityGraphs) {
+        CriteriaQuery<T> criteriaQuery = criteriaBuilder.createQuery(entityClass);
+        Root<T> root = criteriaQuery.from(entityClass);
+
+        ParameterExpression<Long> params = criteriaBuilder.parameter(Long.class);
+        criteriaQuery.where(criteriaBuilder.equal(root.get(ID), params));
+
+        return findByQuery(em.createQuery(criteriaQuery).setParameter(params, id), entityGraphs);
     }
 
     @Transactional

--- a/core/src/main/java/org/n52/sta/data/service/AbstractSensorThingsEntityServiceImpl.java
+++ b/core/src/main/java/org/n52/sta/data/service/AbstractSensorThingsEntityServiceImpl.java
@@ -150,6 +150,19 @@ public abstract class AbstractSensorThingsEntityServiceImpl<T extends StaIdentif
         }
     }
 
+    public S getEntityByIdRaw(Long id, QueryOptions queryOptions) throws STACRUDException {
+        try {
+            S entity = getRepository().findById(id).get();
+            if (queryOptions.hasExpandFilter()) {
+                return fetchExpandEntities(entity, queryOptions.getExpandFilter());
+            } else {
+                return entity;
+            }
+        } catch (RuntimeException | STAInvalidQueryException e) {
+            throw new STACRUDException(e.getMessage(), e);
+        }
+    }
+
     @Override public CollectionWrapper getEntityCollection(QueryOptions queryOptions) throws STACRUDException {
         try {
             Page<S> pages = getRepository().findAll(getFilterPredicate(entityClass, queryOptions),

--- a/core/src/main/java/org/n52/sta/data/service/AbstractSensorThingsEntityServiceImpl.java
+++ b/core/src/main/java/org/n52/sta/data/service/AbstractSensorThingsEntityServiceImpl.java
@@ -152,7 +152,7 @@ public abstract class AbstractSensorThingsEntityServiceImpl<T extends StaIdentif
 
     public S getEntityByIdRaw(Long id, QueryOptions queryOptions) throws STACRUDException {
         try {
-            S entity = getRepository().findById(id).get();
+            S entity = getRepository().findById(id, defaultFetchGraphs).get();
             if (queryOptions.hasExpandFilter()) {
                 return fetchExpandEntities(entity, queryOptions.getExpandFilter());
             } else {

--- a/core/src/main/java/org/n52/sta/data/service/DatastreamService.java
+++ b/core/src/main/java/org/n52/sta/data/service/DatastreamService.java
@@ -32,9 +32,6 @@ package org.n52.sta.data.service;
 import org.n52.janmayen.http.HTTPStatus;
 import org.n52.series.db.beans.DatasetEntity;
 import org.n52.series.db.beans.FormatEntity;
-import org.n52.series.db.beans.PhenomenonEntity;
-import org.n52.series.db.beans.PlatformEntity;
-import org.n52.series.db.beans.ProcedureEntity;
 import org.n52.series.db.beans.UnitEntity;
 import org.n52.series.db.beans.sta.AbstractObservationEntity;
 import org.n52.series.db.beans.sta.DatastreamEntity;
@@ -118,28 +115,19 @@ public class DatastreamService
             if (DatastreamEntityDefinition.NAVIGATION_PROPERTIES.contains(expandProperty)) {
                 switch (expandProperty) {
                 case STAEntityDefinition.SENSOR:
-                    ProcedureEntity sensor = getSensorService()
-                            .getEntityByRelatedEntityRaw(entity.getStaIdentifier(),
-                                                         STAEntityDefinition.DATASTREAMS,
-                                                         null,
-                                                         expandItem.getQueryOptions());
-                    entity.setProcedure(sensor);
+                    entity.setProcedure(getSensorService()
+                            .getEntityByIdRaw(entity.getProcedure().getId(), expandItem.getQueryOptions())
+                    );
                     break;
                 case STAEntityDefinition.THING:
-                    PlatformEntity thing = getThingService()
-                            .getEntityByRelatedEntityRaw(entity.getStaIdentifier(),
-                                                         STAEntityDefinition.DATASTREAMS,
-                                                         null,
-                                                         expandItem.getQueryOptions());
-                    entity.setThing(thing);
+                    entity.setThing(getThingService()
+                            .getEntityByIdRaw(entity.getThing().getId(), expandItem.getQueryOptions())
+                    );
                     break;
                 case STAEntityDefinition.OBSERVED_PROPERTY:
-                    PhenomenonEntity obsProp = getObservedPropertyService()
-                            .getEntityByRelatedEntityRaw(entity.getStaIdentifier(),
-                                                         STAEntityDefinition.DATASTREAMS,
-                                                         null,
-                                                         expandItem.getQueryOptions());
-                    entity.setObservableProperty(obsProp);
+                    entity.setObservableProperty(getObservedPropertyService()
+                            .getEntityByIdRaw(entity.getObservableProperty().getId(), expandItem.getQueryOptions())
+                    );
                     break;
                 case STAEntityDefinition.OBSERVATIONS:
                     Page<ObservationEntity<?>> observations = getObservationService()

--- a/core/src/main/java/org/n52/sta/data/service/FeatureOfInterestService.java
+++ b/core/src/main/java/org/n52/sta/data/service/FeatureOfInterestService.java
@@ -43,6 +43,7 @@ import org.n52.series.db.beans.sta.ObservationEntity;
 import org.n52.series.db.beans.sta.StaFeatureEntity;
 import org.n52.shetland.filter.ExpandFilter;
 import org.n52.shetland.filter.ExpandItem;
+import org.n52.shetland.oasis.odata.query.option.QueryOptions;
 import org.n52.shetland.ogc.sta.exception.STACRUDException;
 import org.n52.shetland.ogc.sta.exception.STAInvalidQueryException;
 import org.n52.shetland.ogc.sta.model.FeatureOfInterestEntityDefinition;
@@ -114,6 +115,20 @@ public class FeatureOfInterestService
     @Override
     public EntityTypes[] getTypes() {
         return new EntityTypes[] {EntityTypes.FeatureOfInterest, EntityTypes.FeaturesOfInterest};
+    }
+
+    public AbstractFeatureEntity<?> getEntityByDatasetIdRaw(Long id, QueryOptions queryOptions) throws STACRUDException {
+        try {
+            Long foiId = datasetRepository.findById(id).get().getFeature().getId();
+            AbstractFeatureEntity<?> entity = getRepository().findById(foiId).get();
+            if (queryOptions.hasExpandFilter()) {
+                return fetchExpandEntities(entity, queryOptions.getExpandFilter());
+            } else {
+                return entity;
+            }
+        } catch (RuntimeException | STAInvalidQueryException e) {
+            throw new STACRUDException(e.getMessage(), e);
+        }
     }
 
     @Override

--- a/core/src/main/java/org/n52/sta/data/service/HistoricalLocationService.java
+++ b/core/src/main/java/org/n52/sta/data/service/HistoricalLocationService.java
@@ -103,12 +103,8 @@ public class HistoricalLocationService
                     entity.setLocations(locations.get().collect(Collectors.toSet()));
                     break;
                 case STAEntityDefinition.THING:
-                    PlatformEntity things = getThingService()
-                            .getEntityByRelatedEntityRaw(entity.getStaIdentifier(),
-                                                         STAEntityDefinition.HISTORICAL_LOCATIONS,
-                                                         null,
-                                                         expandItem.getQueryOptions());
-                    entity.setThing(things);
+                    entity.setThing(getThingService()
+                            .getEntityByIdRaw(entity.getThing().getId(),expandItem.getQueryOptions()));
                     break;
                 default:
                     throw new RuntimeException("This can never happen!");

--- a/core/src/main/java/org/n52/sta/data/service/LocationService.java
+++ b/core/src/main/java/org/n52/sta/data/service/LocationService.java
@@ -29,15 +29,6 @@
 
 package org.n52.sta.data.service;
 
-import java.util.HashSet;
-import java.util.LinkedHashSet;
-import java.util.Optional;
-import java.util.Set;
-import java.util.UUID;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
-
 import org.n52.janmayen.http.HTTPStatus;
 import org.n52.series.db.beans.FormatEntity;
 import org.n52.series.db.beans.PlatformEntity;
@@ -67,11 +58,20 @@ import org.springframework.http.HttpMethod;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
 /**
  * @author <a href="mailto:j.speckamp@52north.org">Jan Speckamp</a>
  */
 @Component
-@DependsOn({ "springApplicationContext" })
+@DependsOn({"springApplicationContext"})
 @Transactional
 public class LocationService
         extends AbstractSensorThingsEntityServiceImpl<LocationRepository, LocationEntity, LocationEntity> {
@@ -89,7 +89,7 @@ public class LocationService
     private Pattern updateFOIPattern = Pattern.compile("(?:.*updateFOI\":\")([0-9A-z'+%-]+)(?:\".*)");
 
     public LocationService(@Value("${server.feature.updateFOI:false}") boolean updateFOI,
-            LocationRepository repository, LocationEncodingRepository locationEncodingRepository) {
+                           LocationRepository repository, LocationEncodingRepository locationEncodingRepository) {
         super(repository, LocationEntity.class);
         this.locationEncodingRepository = locationEncodingRepository;
         this.updateFOIFeatureEnabled = updateFOI;
@@ -97,7 +97,7 @@ public class LocationService
 
     @Override
     public EntityTypes[] getTypes() {
-        return new EntityTypes[] { EntityTypes.Location, EntityTypes.Locations };
+        return new EntityTypes[] {EntityTypes.Location, EntityTypes.Locations};
     }
 
     @Override
@@ -107,24 +107,26 @@ public class LocationService
             String expandProperty = expandItem.getPath();
             if (LocationEntityDefinition.NAVIGATION_PROPERTIES.contains(expandProperty)) {
                 switch (expandProperty) {
-                    case STAEntityDefinition.HISTORICAL_LOCATIONS:
-                        Page<HistoricalLocationEntity> hLocs = getHistoricalLocationService()
-                                .getEntityCollectionByRelatedEntityRaw(entity.getStaIdentifier(),
-                                        STAEntityDefinition.LOCATIONS, expandItem.getQueryOptions());
-                        entity.setHistoricalLocations(hLocs.get().collect(Collectors.toSet()));
-                        break;
-                    case STAEntityDefinition.THINGS:
-                        Page<PlatformEntity> things =
-                                getThingService().getEntityCollectionByRelatedEntityRaw(entity.getStaIdentifier(),
-                                        STAEntityDefinition.LOCATIONS, expandItem.getQueryOptions());
-                        entity.setThings(things.get().collect(Collectors.toSet()));
-                        break;
-                    default:
-                        throw new RuntimeException("This can never happen!");
+                case STAEntityDefinition.HISTORICAL_LOCATIONS:
+                    Page<HistoricalLocationEntity> hLocs = getHistoricalLocationService()
+                            .getEntityCollectionByRelatedEntityRaw(entity.getStaIdentifier(),
+                                                                   STAEntityDefinition.LOCATIONS,
+                                                                   expandItem.getQueryOptions());
+                    entity.setHistoricalLocations(hLocs.get().collect(Collectors.toSet()));
+                    break;
+                case STAEntityDefinition.THINGS:
+                    Page<PlatformEntity> things =
+                            getThingService().getEntityCollectionByRelatedEntityRaw(entity.getStaIdentifier(),
+                                                                                    STAEntityDefinition.LOCATIONS,
+                                                                                    expandItem.getQueryOptions());
+                    entity.setThings(things.get().collect(Collectors.toSet()));
+                    break;
+                default:
+                    throw new RuntimeException("This can never happen!");
                 }
             } else {
                 throw new STAInvalidQueryException("Invalid expandOption supplied. Cannot find " + expandProperty
-                        + " on Entity of type 'Location'");
+                                                           + " on Entity of type 'Location'");
             }
         }
         return entity;
@@ -134,16 +136,16 @@ public class LocationService
     public Specification<LocationEntity> byRelatedEntityFilter(String relatedId, String relatedType, String ownId) {
         Specification<LocationEntity> filter;
         switch (relatedType) {
-            case STAEntityDefinition.HISTORICAL_LOCATIONS: {
-                filter = lQS.withHistoricalLocationStaIdentifier(relatedId);
-                break;
-            }
-            case STAEntityDefinition.THINGS: {
-                filter = lQS.withThingStaIdentifier(relatedId);
-                break;
-            }
-            default:
-                throw new IllegalStateException("Trying to filter by unrelated type: " + relatedType + "not found!");
+        case STAEntityDefinition.HISTORICAL_LOCATIONS: {
+            filter = lQS.withHistoricalLocationStaIdentifier(relatedId);
+            break;
+        }
+        case STAEntityDefinition.THINGS: {
+            filter = lQS.withThingStaIdentifier(relatedId);
+            break;
+        }
+        default:
+            throw new IllegalStateException("Trying to filter by unrelated type: " + relatedType + "not found!");
         }
 
         if (ownId != null) {
@@ -194,8 +196,8 @@ public class LocationService
         if (HttpMethod.PATCH.equals(method)) {
             synchronized (getLock(id)) {
                 Optional<LocationEntity> existing = getRepository().findByStaIdentifier(id,
-                        EntityGraphRepository.FetchGraph.FETCHGRAPH_HIST_LOCATION,
-                        EntityGraphRepository.FetchGraph.FETCHGRAPH_THINGS);
+                                                                                        EntityGraphRepository.FetchGraph.FETCHGRAPH_HIST_LOCATION,
+                                                                                        EntityGraphRepository.FetchGraph.FETCHGRAPH_THINGS);
                 if (existing.isPresent()) {
                     LocationEntity merged = merge(existing.get(), entity);
                     LocationEntity result = getRepository().save(merged);
@@ -220,8 +222,8 @@ public class LocationService
             if (getRepository().existsByStaIdentifier(id)) {
                 LocationEntity location = getRepository()
                         .findByStaIdentifier(id,
-                                EntityGraphRepository.FetchGraph.FETCHGRAPH_HIST_LOCATION,
-                                EntityGraphRepository.FetchGraph.FETCHGRAPH_THINGSHISTLOCATION)
+                                             EntityGraphRepository.FetchGraph.FETCHGRAPH_HIST_LOCATION,
+                                             EntityGraphRepository.FetchGraph.FETCHGRAPH_THINGSHISTLOCATION)
                         .get();
                 for (PlatformEntity thing : location.getThings()) {
                     thing.setLocations(null);
@@ -315,7 +317,7 @@ public class LocationService
                         foiService.updateFeatureOfInterestGeometry(matcher.group(1), location.getGeometry());
                     } else {
                         LOGGER.error("Updating FOI failed as ID could not be extracted from properties:"
-                                + updated.getProperties());
+                                             + updated.getProperties());
                         throw new STACRUDException("Could not extract FeatureOfInterest ID from Thing->properties!");
                     }
                 }

--- a/core/src/main/java/org/n52/sta/data/service/ObservationService.java
+++ b/core/src/main/java/org/n52/sta/data/service/ObservationService.java
@@ -219,7 +219,7 @@ public class ObservationService extends
         try {
             OffsetLimitBasedPageRequest pageableRequest = createPageableRequest(queryOptions);
             Specification<ObservationEntity<?>> spec =
-                    byRelatedStaIdentifier(relatedId, relatedType, null)
+                    byRelatedEntityFilter(relatedId, relatedType, null)
                             .and(getFilterPredicate(ObservationEntity.class, queryOptions));
 
             List<String> identifierList = getRepository().identifierList(spec,

--- a/core/src/main/java/org/n52/sta/data/service/ObservationService.java
+++ b/core/src/main/java/org/n52/sta/data/service/ObservationService.java
@@ -212,6 +212,45 @@ public class ObservationService extends
         }
     }
 
+    protected Page getEntityCollectionByRelatedEntityRaw(String relatedId,
+                                                         String relatedType,
+                                                         QueryOptions queryOptions)
+            throws STACRUDException {
+        try {
+            OffsetLimitBasedPageRequest pageableRequest = createPageableRequest(queryOptions);
+            Specification<ObservationEntity<?>> spec =
+                    byRelatedStaIdentifier(relatedId, relatedType, null)
+                            .and(getFilterPredicate(ObservationEntity.class, queryOptions));
+
+            List<String> identifierList = getRepository().identifierList(spec,
+                                                                         createPageableRequest(queryOptions),
+                                                                         STAIDENTIFIER);
+            if (identifierList.isEmpty()) {
+                return Page.empty();
+            } else {
+                Page<ObservationEntity<?>> pages = getRepository().findAll(
+                        oQS.withStaIdentifier(identifierList),
+                        new OffsetLimitBasedPageRequest(0,
+                                                        pageableRequest.getPageSize(),
+                                                        pageableRequest.getSort()),
+                        EntityGraphRepository.FetchGraph.FETCHGRAPH_PARAMETERS);
+                if (queryOptions.hasExpandFilter()) {
+                    return pages.map(e -> {
+                        try {
+                            return fetchExpandEntities(e, queryOptions.getExpandFilter());
+                        } catch (STACRUDException | STAInvalidQueryException ex) {
+                            throw new RuntimeException(ex);
+                        }
+                    });
+                } else {
+                    return pages;
+                }
+            }
+        } catch (RuntimeException e) {
+            throw new STACRUDException(e.getMessage(), e);
+        }
+    }
+
     @Override
     protected ObservationEntity<?> fetchExpandEntities(ObservationEntity<?> returned,
                                                        ExpandFilter expandOption)

--- a/core/src/main/java/org/n52/sta/data/service/ObservationService.java
+++ b/core/src/main/java/org/n52/sta/data/service/ObservationService.java
@@ -230,11 +230,9 @@ public class ObservationService extends
                     returned.setDatastream(datastream);
                     break;
                 case STAEntityDefinition.FEATURE_OF_INTEREST:
-                    AbstractFeatureEntity<?> foi = getFeatureOfInterestService()
-                            .getEntityByRelatedEntityRaw(returned.getStaIdentifier(),
-                                                         STAEntityDefinition.OBSERVATIONS,
-                                                         null,
-                                                         expandItem.getQueryOptions());
+                    AbstractFeatureEntity<?> foi = ((FeatureOfInterestService)
+                            getFeatureOfInterestService()).getEntityByDatasetIdRaw(returned.getDataset().getId(),
+                                                                                   expandItem.getQueryOptions());
                     returned.setFeature(foi);
                     break;
                 default:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
     - database
 
   database:
-    image: mdillon/postgis
+    image: postgis/postgis:12-master
     restart: on-failure
     environment:
       - POSTGRES_DB=sta


### PR DESCRIPTION
Previously in-memory pagination was used when expand via $expand. Especially for `Datastreams($expand=Observations)` this lead to a huge slowdown as the Observations table can be huge